### PR TITLE
Remove unsupported qBittorrent search category

### DIFF
--- a/limetorrents.py
+++ b/limetorrents.py
@@ -1,4 +1,4 @@
-#VERSION: 3.08
+#VERSION: 3.09
 #AUTHORS: Lima66
 
 try:
@@ -21,8 +21,7 @@ class limetorrents(object):
                             'games': 'games',
                             'movies': 'movies',
                             'music': 'music',
-                            'tv': 'tv',
-                            'other': 'other'}
+                            'tv': 'tv'}
 
     def download_torrent(self, info):
         print(download_file(info))


### PR DESCRIPTION
Issue here: https://github.com/qbittorrent/qBittorrent/issues/7109#issuecomment-316891656

qBittorrent was displaying an empty entry in the search categories - this fixes this issue. 